### PR TITLE
Change final write format to ORC

### DIFF
--- a/testing_spark.py
+++ b/testing_spark.py
@@ -22,5 +22,5 @@ sorted_df = grouped_df.sort("avg_salary", ascending=False)
 # Select top 3 departments
 top3_df = sorted_df.limit(3)
 
-# Write result to Parquet
-top3_df.write.parquet("output/top_departments.parquet")
+# Write result to ORC
+top3_df.write.orc("output/top_departments.orc")


### PR DESCRIPTION
Changed the final write format from Parquet to ORC in the file `testing_spark.py`. This change ensures compatibility with systems that prefer ORC format for data storage and processing.